### PR TITLE
Add rustls-tls feature that selects reqwest/rustls-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ required-features = ["cli"]
 
 [dependencies]
 failure = "0.1.5"
-reqwest = "0.9"
+reqwest = {version = "0.9", default-features = false}
 serde_json = "1.0.39"
 log = "0.4.14"
 env_logger = "0.9.0"
@@ -33,4 +33,7 @@ features = ["derive"]
 version = "1.0.93"
 
 [features]
+default = ["default-tls"]
 cli = ["clap"]
+default-tls = ["reqwest/default-tls"]
+rustls-tls = ["reqwest/rustls-tls"]


### PR DESCRIPTION
## Description of the change

> Added a new feature that switches TLS implementation from openssl-sys to rustls

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> #2 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
