### PR TITLE
upgrade dependencies, reqwest from `0.9` to `0.11`, clap from `2.33` to `3.2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,23 +14,23 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-failure = "0.1.5"
-reqwest = {version = "0.9", default-features = false}
-serde_json = "1.0.39"
-log = "0.4.14"
-env_logger = "0.9.0"
+failure = "0.1"
+reqwest = { version = "0.11", default-features = false, features=['json', 'blocking']}
+serde_json = "1.0"
+log = "0.4"
+env_logger = "0.9"
 
 [dependencies.chrono]
 features = ["serde"]
-version = "0.4.6"
+version = "0.4"
 
 [dependencies.clap]
 optional = true
-version = "2.33"
+version = "3.2"
 
 [dependencies.serde]
 features = ["derive"]
-version = "1.0.93"
+version = "1.0"
 
 [features]
 default = ["default-tls"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,7 @@ use log::debug;
 pub struct RudderAnalytics {
     pub write_key: String,
     pub data_plane_url: String,
-    pub client: reqwest::Client,
+    pub client: reqwest::blocking::Client,
 }
 
 
@@ -20,7 +20,7 @@ impl RudderAnalytics {
         RudderAnalytics {
             write_key,
             data_plane_url,
-            client: reqwest::Client::builder()
+            client: reqwest::blocking::Client::builder()
                 .connect_timeout(Duration::new(10, 0))
                 .build()
                 .unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Error> {
             Arg::with_name("write-key")
                 .help("Write key to send message with")
                 .takes_value(true)
-                .short("w")
+                .short('w')
                 .long("write-key")
                 .required(true),
         )
@@ -23,7 +23,7 @@ fn main() -> Result<(), Error> {
             Arg::with_name("data-plane-url")
                 .help("Base url to send to your data")
                 .takes_value(true)
-                .short("d")
+                .short('d')
                 .long("data-plane-url")
                 .required(true),
         )


### PR DESCRIPTION
## Description of the change

upgrade outdated dependencies, reqwest from `0.9` to `0.11`, clap from `2.33` to `3.2`

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

there are 52 clippy warnings but this change doesn't add any new ones...

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
