### PR TITLE
fix: context override in batch

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -253,6 +253,9 @@ pub fn parse_batch(msg:&Batch)-> Ruddermessage{
     for i in &msg.batch {
         match i {
             BatchMessage::Identify(a_) =>{
+                let mut final_context: Value = a_.context.clone().unwrap_or(json!({}));
+                merge(&mut final_context, modified_context.clone() );
+
                 batch.push(Rudderbatchmessage::Identify(Rudderidentify 
                 {
                     user_id: a_.user_id.clone(),
@@ -261,12 +264,15 @@ pub fn parse_batch(msg:&Batch)-> Ruddermessage{
                     original_timestamp: original_timestamp,
                     sent_at: Some(sent_at),
                     integrations: a_.integrations.clone(),
-                    context: Some(modified_context.clone()),
+                    context: Some(final_context),
                     r#type: String::from("identify"),
                     channel: CHANNEL.to_string()
                 }));
             },           
             BatchMessage::Track(a_) =>{
+                let mut final_context: Value = a_.context.clone().unwrap_or(json!({}));
+                merge(&mut final_context, modified_context.clone());
+
                 batch.push(Rudderbatchmessage::Track(
                     Ruddertrack {
                         user_id: a_.user_id.clone(),
@@ -276,13 +282,16 @@ pub fn parse_batch(msg:&Batch)-> Ruddermessage{
                         original_timestamp: original_timestamp,
                         sent_at: Some(sent_at),
                         integrations: a_.integrations.clone(),
-                        context: Some(modified_context.clone()),
+                        context: Some(final_context),
                         r#type: String::from("track"),
                         channel: CHANNEL.to_string()
                     }
                 ));
             },           
             BatchMessage::Page(a_) =>{
+                let mut final_context: Value = a_.context.clone().unwrap_or(json!({}));
+                merge(&mut final_context, modified_context.clone());
+
                 batch.push(Rudderbatchmessage::Page(
                     Rudderpage {
                         user_id: a_.user_id.clone(),
@@ -292,13 +301,16 @@ pub fn parse_batch(msg:&Batch)-> Ruddermessage{
                         original_timestamp: original_timestamp,
                         sent_at: Some(sent_at),
                         integrations: a_.integrations.clone(),
-                        context: Some(modified_context.clone()),
+                        context: Some(final_context),
                         r#type: String::from("page"),
                         channel: CHANNEL.to_string()
                     }
                 ));
             },           
             BatchMessage::Screen(a_) =>{
+                let mut final_context: Value = a_.context.clone().unwrap_or(json!({}));
+                merge(&mut final_context, modified_context.clone());
+
                 batch.push(Rudderbatchmessage::Screen(
                     Rudderscreen {
                         user_id: a_.user_id.clone(),
@@ -308,13 +320,16 @@ pub fn parse_batch(msg:&Batch)-> Ruddermessage{
                         original_timestamp: original_timestamp,
                         sent_at: Some(sent_at),
                         integrations: a_.integrations.clone(),
-                        context: Some(modified_context.clone()),
+                        context: Some(final_context),
                         r#type: String::from("screen"),
                         channel: CHANNEL.to_string()
                     }
                 ));
             },           
             BatchMessage::Group(a_) =>{
+                let mut final_context: Value = a_.context.clone().unwrap_or(json!({}));
+                merge(&mut final_context, modified_context.clone());
+
                 batch.push(Rudderbatchmessage::Group(
                     Ruddergroup {
                         user_id: a_.user_id.clone(),
@@ -324,13 +339,16 @@ pub fn parse_batch(msg:&Batch)-> Ruddermessage{
                         original_timestamp: original_timestamp,
                         sent_at: Some(sent_at),
                         integrations: a_.integrations.clone(),
-                        context: Some(modified_context.clone()),
+                        context: Some(final_context),
                         r#type: String::from("group"),
                         channel: CHANNEL.to_string()
                     }
                 ));
             },           
             BatchMessage::Alias(a_) =>{
+                let mut final_context: Value = a_.context.clone().unwrap_or(json!({}));
+                merge(&mut final_context, modified_context.clone());
+
                 batch.push(Rudderbatchmessage::Alias(
                     Rudderalias {
                         user_id: a_.user_id.clone(),
@@ -339,7 +357,7 @@ pub fn parse_batch(msg:&Batch)-> Ruddermessage{
                         original_timestamp: original_timestamp,
                         sent_at: Some(sent_at),
                         integrations: a_.integrations.clone(),
-                        context: Some(modified_context.clone()),
+                        context: Some(final_context),
                         r#type: String::from("alias"),
                         channel: CHANNEL.to_string()
                     }


### PR DESCRIPTION
## Description of the change

https://linear.app/rudderstack/issue/SDK-2178/fix-context-overridden-in-batched-events

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
