### PR TITLE
chore: add DeepWiki badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <p align="center"><a href="https://rudderstack.com"><img src="https://user-images.githubusercontent.com/59817155/126267034-ae9870b7-9137-4f45-be65-d621b055a972.png" alt="RudderStack - Customer Data Platform for Developers" height="50"/></a></p>
 <h1 align="center"></h1>
 <p align="center"><b>Customer Data Platform for Developers</b></p>
+<p align="center"><a href="https://deepwiki.com/rudderlabs/rudder-sdk-rust"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"/></a></p>
 <br/>
 
 # About RudderStack


### PR DESCRIPTION
## Description

Add a DeepWiki badge to the README header section. The badge links to the [DeepWiki page for this repository](https://deepwiki.com/rudderlabs/rudder-sdk-rust), providing quick access to AI-generated documentation and code understanding.

## Changes

- Added a DeepWiki badge (`https://deepwiki.com/badge.svg`) to `README.md`, placed below the "Customer Data Platform for Developers" tagline.

## Linear Task

SDK-4560
