### PR TITLE
chore(codeowners): set sdk_team as code owners

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "BUG : <Title>"
 labels: bug, open source
-assignees: itsdebs
+assignees: []
 ---
 
 **Describe the bug**

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-@saikumarrs
-@MoumitaM
+* @rudderlabs/sdk_team


### PR DESCRIPTION
## Summary

Replaces the code owners with the `@rudderlabs/sdk_team` team so any SDK team member's review can unblock chore PRs (Dependabot merges, CI fixes). The previous file listed two bare usernames (`@saikumarrs`, `@MoumitaM`) with no path pattern — malformed CODEOWNERS syntax that GitHub ignores, so no review routing was happening at all. This fixes the syntax and brings the repo in line with the other SDK repos already migrated.

## Changes

- `CODEOWNERS`: replaced the two malformed bare-username lines with `* @rudderlabs/sdk_team`
- `.github/ISSUE_TEMPLATE/bug_report.md`: clears the hardcoded individual assignee (`itsdebs` → `[]`), matching the pattern used in the other SDK repos

## Testing

Config-only change — after merge, confirm the CODEOWNERS syntax error is gone in GitHub's file view and verify on the next chore PR that review is auto-requested from `sdk_team`. New bug reports should open unassigned.

## Screenshots

No UI changes in this PR.

## Notes

Fixes [SDK-5176](https://linear.app/rudderstack/issue/SDK-5176/set-sdk-team-as-code-owners-in-rudder-sdk-rust). No breaking changes or migration steps required.
